### PR TITLE
Revert "Remove autogen ingrasys debian files"

### DIFF
--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.dirs
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.dirs
@@ -1,0 +1,4 @@
+usr/sbin
+lib/systemd/system
+etc/
+etc/init.d/

--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.install
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.install
@@ -1,0 +1,4 @@
+lib/systemd/
+usr/sbin/
+etc/
+etc/init.d/

--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.postinst
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.postinst
@@ -1,0 +1,57 @@
+# Automatically added by dh_systemd_enable
+# This will only remove masks created by d-s-h on package removal.
+deb-systemd-helper unmask s9180-32x-monitor.service >/dev/null || true
+deb-systemd-helper unmask bfn.service >/dev/null || true
+deb-systemd-helper unmask qsfp-monitor.service >/dev/null || true
+# Generate kernel modules.dep and map files for add eeprom_mb.
+depmod -a || true
+# was-enabled defaults to true, so new installations run enable.
+if deb-systemd-helper --quiet was-enabled s9180-32x-monitor.service; then
+    # Enables the unit on first installation, creates new
+    # symlinks on upgrades if the unit file has changed.
+    deb-systemd-helper enable s9180-32x-monitor.service >/dev/null || true
+else
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state s9180-32x-monitor.service >/dev/null || true
+fi
+if deb-systemd-helper --quiet was-enabled bfn.service; then
+    # Enables the unit on first installation, creates new
+    # symlinks on upgrades if the unit file has changed.
+    deb-systemd-helper enable bfn.service >/dev/null || true
+else
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state bfn.service >/dev/null || true
+fi
+if deb-systemd-helper --quiet was-enabled qsfp-monitor.service; then
+    # Enables the unit on first installation, creates new
+    # symlinks on upgrades if the unit file has changed.
+    deb-systemd-helper enable qsfp-monitor.service >/dev/null || true
+else
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state qsfp-monitor.service >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by dh_installinit
+if [ -x "/etc/init.d/s9180-32x-monitor" ]; then
+    update-rc.d s9180-32x-monitor defaults >/dev/null
+    invoke-rc.d s9180-32x-monitor start || exit $?
+fi
+if [ -x "/etc/init.d/qsfp-monitor" ]; then
+    update-rc.d qsfp-monitor defaults >/dev/null
+    invoke-rc.d qsfp-monitor start || exit $?
+fi
+if [ -x "/etc/init.d/bfn" ]; then
+    invoke-rc.d bfn start || exit $?
+fi
+# End automatically added section
+# Automatically added by dh_systemd_start
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+    deb-systemd-invoke start s9180-32x-monitor.service >/dev/null || true
+    deb-systemd-invoke start qsfp-monitor.service >/dev/null || true
+    deb-systemd-invoke start bfn.service >/dev/null || true
+fi
+# End automatically added section

--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.postrm
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.postrm
@@ -1,0 +1,42 @@
+# Automatically added by dh_systemd_start
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+    fi
+# End automatically added section
+# Automatically added by dh_installinit
+if [ "$1" = "purge" ] ; then
+    update-rc.d s9180-32x-monitor remove >/dev/null
+    update-rc.d bfn remove >/dev/null
+    update-rc.d qsfp-monitor remove >/dev/null
+fi
+
+
+# In case this system is running systemd, we make systemd reload the unit files
+# to pick up changes.
+if [ -d /run/systemd/system ] ; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by dh_systemd_enable
+if [ "$1" = "remove" ]; then
+    if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper mask s9180-32x-monitor.service >/dev/null
+        deb-systemd-helper mask bfn.service >/dev/null
+        deb-systemd-helper mask qsfp-monitor.service >/dev/null
+    fi
+fi
+
+if [ "$1" = "purge" ]; then
+    if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper purge s9180-32x-monitor.service >/dev/null
+        deb-systemd-helper unmask s9180-32x-monitor.service >/dev/null
+        deb-systemd-helper purge bfn.service >/dev/null
+        deb-systemd-helper unmask bfn.service >/dev/null
+        deb-systemd-helper purge qsfp-monitor.service >/dev/null
+        deb-systemd-helper unmask qsfp-monitor.service >/dev/null
+    fi
+fi
+# Generate kernel modules.dep and map files for remove eeprom_mb.
+depmod -a || true
+# End automatically added section
+

--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.prerm
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9180-32x.prerm
@@ -1,0 +1,21 @@
+# Automatically added by dh_systemd_start
+if [ -d /run/systemd/system ]; then
+    deb-systemd-invoke stop s9180-32x-monitor.service >/dev/null
+    deb-systemd-invoke stop bfn.service >/dev/null
+    deb-systemd-invoke stop qsfp-monitor.service >/dev/null
+fi
+# End automatically added section
+# Automatically added by dh_installinit
+if [ -x "/etc/init.d/s9180-32x-monitor" ]; then
+    invoke-rc.d s9180-32x-monitor stop || exit $?
+fi
+if [ -x "/etc/init.d/bfn" ]; then
+    invoke-rc.d bfn stop || exit $?
+fi
+if [ -x "/etc/init.d/qsfp-monitor" ]; then
+    invoke-rc.d qsfp-monitor stop || exit $?
+fi
+# Driver deinit
+/usr/sbin/i2c_utils.sh i2c_deinit
+# End automatically added section
+


### PR DESCRIPTION
Reverts barefootnetworks/sonic-buildimage#19

These changes somehow seem to be breaking build for bfn. Adding these in for now. We shall have ingrasys folk review these later and update them.